### PR TITLE
add -D_LARGEFILE64_SOURCE for musl builds to support sendfile64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/assets/styles/main.css.map
 tests/xxhash.h
 tests/xxhash.c
 tests/words.txt
+
+zig-out
+zig-cache

--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,8 @@ pub fn build(b: *std.Build) !void {
     //
 
     try flags.append("-DFIO_HTTP_EXACT_LOGGING");
+    if (target.getAbi() == .musl)
+        try flags.append("-D_LARGEFILE64_SOURCE");
 
     // Include paths
     lib.addIncludePath(".");


### PR DESCRIPTION
Noticed https://github.com/zigzap/zap/issues/30 while preparing this PR, I think this patch is far less involved. I've tested building and running example programs over at https://github.com/mattnite/zap.

As for some explanation around `-D_LARGEFILE64_SOURCE`, I found [this FAQ](https://github.com/somasis/musl-wiki/blob/master/faq.md#q-do-i-need-to-define-_largefile64_source-to-get-64bit-off_t) that explains:

> `-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE` have nothing to do with supporting large files properly but with exposing the idiotic legacy interfaces with 64 on the end of their names

Which seems to line up with our issue. It seems to me that some research is needed to determine if `sendfile64` is really needed, and if it isn't, then we could upstream a simplification.