### PR TITLE
upgrade zig build api to 0.12.0-dev.891+2254882eb

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -50,24 +50,27 @@ pub fn build(b: *std.Build) !void {
     lib.addIncludePath(.{ .path = "lib/facil/http/parsers" });
 
     // C source files
-    lib.addCSourceFiles(&.{
-        "lib/facil/fio.c",
-        "lib/facil/fio_zig.c",
-        "lib/facil/http/http.c",
-        "lib/facil/http/http1.c",
-        "lib/facil/http/websockets.c",
-        "lib/facil/http/http_internal.c",
-        "lib/facil/fiobj/fiobj_numbers.c",
-        "lib/facil/fiobj/fio_siphash.c",
-        "lib/facil/fiobj/fiobj_str.c",
-        "lib/facil/fiobj/fiobj_ary.c",
-        "lib/facil/fiobj/fiobj_data.c",
-        "lib/facil/fiobj/fiobj_hash.c",
-        "lib/facil/fiobj/fiobj_json.c",
-        "lib/facil/fiobj/fiobject.c",
-        "lib/facil/fiobj/fiobj_mustache.c",
-        "lib/facil/cli/fio_cli.c",
-    }, flags.items);
+    lib.addCSourceFiles(.{
+        .flags = flags.items,
+        .files = &.{
+            "lib/facil/fio.c",
+            "lib/facil/fio_zig.c",
+            "lib/facil/http/http.c",
+            "lib/facil/http/http1.c",
+            "lib/facil/http/websockets.c",
+            "lib/facil/http/http_internal.c",
+            "lib/facil/fiobj/fiobj_numbers.c",
+            "lib/facil/fiobj/fio_siphash.c",
+            "lib/facil/fiobj/fiobj_str.c",
+            "lib/facil/fiobj/fiobj_ary.c",
+            "lib/facil/fiobj/fiobj_data.c",
+            "lib/facil/fiobj/fiobj_hash.c",
+            "lib/facil/fiobj/fiobj_json.c",
+            "lib/facil/fiobj/fiobject.c",
+            "lib/facil/fiobj/fiobj_mustache.c",
+            "lib/facil/cli/fio_cli.c",
+        },
+    });
 
     // link against libc
     lib.linkLibC();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
+    .paths = .{""},
     .name = "facil.io",
     .version = "0.0.12",
 }
-


### PR DESCRIPTION
addCSourceFiles now needs a Options struct, and build.zig.zon needs a `paths` key.

this fixes the build, but i haven't figured out why the "facil.io" artifact is not found on the zap side